### PR TITLE
Rotate auth0 creds and tweak dev/ci config a little

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,11 @@ jobs:
       - run:
           name: "Test"
           command: "./bin/kaocha"
+          environment:
+            - AUTH0_DOMAIN: https://dev-kkt-m758.eu.auth0.com
+            - AUTH0_CLIENT_ID: rP6sBtate52nxTs5KIHH8pcGInMBGh8a
+            - AUTH0_AUD: https://dev-kkt-m758.eu.auth0.com/api/v2/
+
       - store_test_results:
           path: test-results
 
@@ -31,4 +36,4 @@ workflows:
       - test:
           context:
             - swirrl-dockerhub-consumer
-            - swirrl-auth0-dev-tennant # creds for our auth0 dev setup
+            - swirrl-auth0-auth0-dev-creds # creds for our auth0 dev setup

--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,11 @@
+export AUTH0_DOMAIN="https://dev-kkt-m758.eu.auth0.com"
+export AUTH0_CLIENT_ID="rP6sBtate52nxTs5KIHH8pcGInMBGh8a"
+
+# Swirrlers can find the secret for the above client in the auth0
+# dashboard here:
+#
+#    https://manage.auth0.com/dashboard/eu/dev-kkt-m758/applications/rP6sBtate52nxTs5KIHH8pcGInMBGh8a/settings
+#
+# Or in 1password under the swirrl-auth0-auth0-dev-creds item.
+#
+export AUTH0_CLIENT_SECRET="INSERT_SECRET_HERE"


### PR DESCRIPTION
What happened here?

- We change the auth0 creds so we're no longer using muttniks dev/ci ones.  
- We create a new [auth0 Application](https://manage.auth0.com/dashboard/eu/dev-kkt-m758/applications/rP6sBtate52nxTs5KIHH8pcGInMBGh8a/settings) called `swirrl-auth0-test-client` and assign a new clientid 
- We tweak all the CI contexts/permissions to use it
- We add a `.envrc` to swirrls 1password

The outcome of this is that this decouples this completely from muttnik and the `http://pmd` audience.  The tests in this project are written against auth0's management API so we now configure an aud of `https://dev-kkt-m758.eu.auth0.com/api/v2/` , not `http://pmd`.