### PR TITLE
Track token expiry time

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,5 +1,6 @@
 export AUTH0_DOMAIN="https://dev-kkt-m758.eu.auth0.com"
 export AUTH0_CLIENT_ID="rP6sBtate52nxTs5KIHH8pcGInMBGh8a"
+export AUTH0_AUD="https://pmd"
 
 # Swirrlers can find the secret for the above client in the auth0
 # dashboard here:

--- a/src/swirrl/auth0/client.clj
+++ b/src/swirrl/auth0/client.clj
@@ -2,7 +2,6 @@
   (:require [cheshire.core :as json]
             [clj-http.client :refer [unexceptional-status?]]
             [clj-time.core :as time]
-            [clj-time.coerce :as time.coerce]
             [clojure.set :as set]
             [clojure.walk :as walk]
             [integrant.core :as ig]

--- a/src/swirrl/auth0/client.clj
+++ b/src/swirrl/auth0/client.clj
@@ -50,7 +50,7 @@
       (vary-meta assoc :timestamp (time/now))))
 
 (defn client-id-token-expiry-time
-  "Takses auth0 client and returns clj-time/date-time or nil.
+  "Takes auth0 client and returns clj-time/date-time or nil.
   The returned date-time marks the instant the token expires."
   [auth0]
   (let [{expires-in :expires_in :as token} (some-> auth0 :client-id-token deref)

--- a/src/swirrl/auth0/client.clj
+++ b/src/swirrl/auth0/client.clj
@@ -3,7 +3,6 @@
             [clj-http.client :refer [unexceptional-status?]]
             [clj-time.core :as time]
             [clojure.set :as set]
-            [clojure.walk :as walk]
             [integrant.core :as ig]
             [martian.core :as martian]
             [ring.util.codec :refer [form-encode]]

--- a/src/swirrl/auth0/martian.clj
+++ b/src/swirrl/auth0/martian.clj
@@ -34,9 +34,17 @@
   {:name ::unexceptional
    :enter (fn [ctx] (assoc-in ctx [:request :unexceptional-status] pred))})
 
+(def cookie-policy
+  "The default cookie policy doesn't handle some of the response cookies
+  and spams warnings in the logs, so we use :standard one. This is a
+  clj-http option."
+  {:name ::cookie-policy
+   :enter (fn [ctx] (assoc-in ctx [:request :cookie-policy] :standard))})
+
 (def default-interceptors
   (conj martian/default-interceptors
         never-coerce-response-body
         (interceptors/encode-body default-encoders)
         (interceptors/coerce-response default-encoders)
+        cookie-policy
         martian-http/perform-request))

--- a/src/swirrl/auth0/refresher.clj
+++ b/src/swirrl/auth0/refresher.clj
@@ -1,0 +1,93 @@
+(ns swirrl.auth0.refresher
+  "Most access tokens expire and need to be refreshed. This namespace
+  lets us schedule a periodic refresh.
+
+  The refrehs relies on the value returned by
+  `swirrl.auth0.client/client-id-expiry-token`"
+  (:require [clj-time.core :as time]
+            [clojure.tools.logging :as log]
+            [integrant.core :as ig]
+            [swirrl.auth0.client :as auth0 :refer [nonce]])
+  (:import [java.util.concurrent
+            RejectedExecutionException
+            ThreadFactory 
+            ScheduledThreadPoolExecutor 
+            ScheduledExecutorService
+            TimeUnit]))
+
+(defn- refresh-interval
+  "Returns an interval between now and expiry time.
+
+  Note: the returned interval may be zero (e.g. when we're past the
+  expiry time). See [[clj-time.core/interval]]"
+  [now expiry-time]
+  (if (time/after? now expiry-time)
+    (time/interval now now)
+    (time/interval now expiry-time)))
+
+(defn- refresh-token!
+  "Refreshes the token. Returns the expiry time of new token on success.
+  Throws if request failed. `ex-data` will be tagged with one of
+  the following tags: ::refresh-failed, ::no-expiry-time."
+  [auth0]
+  (try
+    (auth0/set-client-id-token! auth0)
+    (catch Exception ex
+      (throw (ex-info "Failed to refresh token" {:tag ::refresh-failed}))))
+  (if-let [t (auth0/client-id-token-expiry-time auth0)]
+    t
+    (throw (ex-info "No expiry time token" {:tag ::no-expiry-time}))))
+
+(def ^:private default-id-token-opts
+  {:initial-delay-in-seconds 0 :retry-delay-in-seconds 30})
+
+(defn- refresher-fn
+  "Schedules an auth0 id-token refresh based on expiry time cashed by
+  the auth0 client (if any). Retries when refresh fails."
+  [{:keys [auth0 retry-delay-in-seconds]} ^ScheduledExecutorService executor]
+  (try
+    (let [expiry-time (refresh-token! auth0)
+          ^long interval-minutes (->> (refresh-interval (time/now) expiry-time)
+                                      (time/in-minutes))]
+      (log/info (format "Refreshed. New token expires in %s minutes" interval-minutes)
+                {:new-expiry-time expiry-time})
+      (.schedule executor
+                 ^Runnable (partial refresher-fn auth0 executor) 
+                 interval-minutes 
+                 TimeUnit/MINUTES))
+    (catch clojure.lang.ExceptionInfo ex
+      (when (contains? #{:refresh-failed ::no-expiry-time} (-> ex ex-data :tag))
+        (log/info ex "Failed to refresh the auth0 token. Will retry")
+        (.schedule executor 
+                   ^Runnable (partial refresher-fn auth0 executor)
+                   retry-delay-in-seconds
+                   TimeUnit/SECONDS)))
+    (catch Exception ex
+      (log/warn ex "Failure when refreshing auth0 client token."))))
+
+(defmethod ig/init-key :swirrl.auth0.refresher/id-token
+  [_ {:keys [auth0] :as opts}]
+  (let [exec (ScheduledThreadPoolExecutor. 1 (reify ThreadFactory
+                                               (newThread [_ runnable]
+                                                 (Thread. runnable "id-token-refresher"))))
+        {:keys [initial-delay-in-seconds]
+         :as opts} (merge default-id-token-opts opts)]
+    (doto exec
+      ;; let's not rely on remembering what the defaults are
+      (.setExecuteExistingDelayedTasksAfterShutdownPolicy false)
+      (.setContinueExistingPeriodicTasksAfterShutdownPolicy false))
+    (try
+      (log/debug "Token already present? " (auth0/client-id-token? auth0))
+      (log/info "Scheduling initial id-token fetch.")
+      (.schedule exec (partial refresher-fn opts exec)
+                 initial-delay-in-seconds 
+                 TimeUnit/SECONDS)
+      (catch RejectedExecutionException ex
+        ;; we can't periodically refresh, but we should still be able
+        ;; to start the system, so not rethrowing
+        (log/warn ex "could not schedule auth token refreshing thread:" (ex-message ex))))
+    
+    exec))
+
+(defmethod ig/halt-key! :swirrl.auth0.refresher/id-token [kw executor]
+  (.shutdown executor))

--- a/src/swirrl/auth0/refresher.clj
+++ b/src/swirrl/auth0/refresher.clj
@@ -2,12 +2,14 @@
   "Most access tokens expire and need to be refreshed. This namespace
   lets us schedule a periodic refresh.
 
+  See [[default-id-token-opts]] for options you can pass from config.
+
   The refrehs relies on the value returned by
   `swirrl.auth0.client/client-id-expiry-token`"
   (:require [clj-time.core :as time]
             [clojure.tools.logging :as log]
             [integrant.core :as ig]
-            [swirrl.auth0.client :as auth0 :refer [nonce]])
+            [swirrl.auth0.client :as auth0])
   (:import [java.util.concurrent
             RejectedExecutionException
             ThreadFactory 
@@ -33,7 +35,7 @@
   (try
     (auth0/set-client-id-token! auth0)
     (catch Exception ex
-      (throw (ex-info "Failed to refresh token" {:tag ::refresh-failed}))))
+      (throw (ex-info "Failed to refresh token" {:tag ::refresh-failed} ex))))
   (if-let [t (auth0/client-id-token-expiry-time auth0)]
     t
     (throw (ex-info "No expiry time token" {:tag ::no-expiry-time}))))
@@ -89,5 +91,5 @@
     
     exec))
 
-(defmethod ig/halt-key! :swirrl.auth0.refresher/id-token [kw executor]
+(defmethod ig/halt-key! :swirrl.auth0.refresher/id-token [_ executor]
   (.shutdown executor))

--- a/test/swirrl/auth0/client_test.clj
+++ b/test/swirrl/auth0/client_test.clj
@@ -22,17 +22,22 @@
 (s/def ::expires_in integer?)
 (s/def ::token_type #{"Bearer"})
 (s/def ::client-id-token
-  (s/keys :req-un [::access_token ::scope ::expires_in ::token_type]))
+  (s/keys :req-un [::access_token ::expires_in ::token_type]))
 
 (deftest auth0-client-test
   (testing "Client instantiation"
     (let [sys (auth0-system)
           client (:swirrl.auth0/client sys)
-          jwk (:swirrl.auth0/jwk sys)]
-      (is (instance? swirrl.auth0.client.Auth0Client client))
+          jwk (:swirrl.auth0/jwk sys)]      (is (instance? swirrl.auth0.client.Auth0Client client))
       (is (instance? com.auth0.jwk.JwkProvider jwk))
       (let [token (sut/get-client-id-token client)]
-        (is (s/valid? ::client-id-token token))))))
+        (sut/client-id-token-expiry-time client)
+        (is (s/valid? ::client-id-token token))
+        (is (-> token meta :timestamp)))
+      
+      (testing "Client remembers last refresh time"
+        (sut/set-client-id-token! client)
+        (is (sut/client-id-token-expiry-time client))))))
 
 (s/def ::email string?)
 (s/def ::name string?)


### PR DESCRIPTION
**Problem**: 
The auth0 response (which we hold on to) includes `expiry_time` (in seconds), but:
1. We don't store the reference point (N seconds starting from _when_?)
2. We could potentially task the user with keeping track of that, but even then the response map is not exposed (and probably shouldn't be).
3. There is no convenient way to refresh the token

**Solution**: 
Ad.1. Store a timestamp in the response metadata.
Ad.2. add `swirrl.auth0.client/client-id-token-expiry-time` function returning the token expiry date-time (or nil).
Ad.3. add `swirrl.auth0.refresher` namespace containing integrant init/halt methods for`:swirrl.auth0.refresher/id-token`(moved from muttnik's PR)

Additional changes:
- fix cookie warnings in auth0 responses
- add missing env var to .envrc.template`

