### PR TITLE
fix: proper :aud for management API calls

### DIFF
--- a/src/swirrl/auth0/refresher.clj
+++ b/src/swirrl/auth0/refresher.clj
@@ -38,7 +38,7 @@
       (throw (ex-info "Failed to refresh token" {:tag ::refresh-failed} ex))))
   (if-let [t (auth0/client-id-token-expiry-time auth0)]
     t
-    (throw (ex-info "No expiry time token" {:tag ::no-expiry-time}))))
+    (throw (ex-info "No expiry time" {:tag ::no-expiry-time}))))
 
 (def ^:private default-id-token-opts
   {:initial-delay-in-seconds 0 :retry-delay-in-seconds 30})

--- a/src/swirrl/auth0/refresher.clj
+++ b/src/swirrl/auth0/refresher.clj
@@ -33,7 +33,7 @@
   the following tags: ::refresh-failed, ::no-expiry-time."
   [auth0]
   (try
-    (auth0/set-client-id-token! auth0)
+    (auth0/set-client-id-token! (auth0/management-api-client auth0))
     (catch Exception ex
       (throw (ex-info "Failed to refresh token" {:tag ::refresh-failed} ex))))
   (if-let [t (auth0/client-id-token-expiry-time auth0)]


### PR DESCRIPTION
Bug found when trying to remove uses of `swirrl.auth0.client/api` function, which creates its own client instance and swallows auth errors. That behaviour masked the wrong `:aud` value passed when obtaining the ID token (to access Auth0 management API). Even though we successfully authenticated (but with wrong `:aud`), the `api` function got 401  response, then re-authenticated (passing correct `:aud`) and re-tried the call.

**Change summary**
- introduces `management-api-client` helper to make the `:aud` swap explicit 
- introduces `management-api` function to be used in place of deprecated `swirrl.auth0.client/api`
- updates the id token refresher to use management API client